### PR TITLE
Add error, link error, panel lock and initialized attributes for devices

### DIFF
--- a/maxcube/device.py
+++ b/maxcube/device.py
@@ -15,6 +15,18 @@ MAX_DEVICE_MODE_BOOST = 3
 MAX_DEVICE_BATTERY_OK = 0
 MAX_DEVICE_BATTERY_LOW = 1
 
+MAX_DEVICE_PANEL_UNLOCKED = 0
+MAX_DEVICE_PANEL_LOCKED = 1
+
+MAX_DEVICE_LINK_STATUS_OK = 0
+MAX_DEVICE_LINK_STATUS_ERROR = 1
+
+MAX_DEVICE_STATUS_NOT_INITIALIZED = 0
+MAX_DEVICE_STATUS_INITIALIZED = 1
+
+MAX_DEVICE_ERROR_NO = 0
+MAX_DEVICE_ERROR_YES = 1
+
 MODE_NAMES = {
     MAX_DEVICE_MODE_AUTOMATIC: "auto",
     MAX_DEVICE_MODE_MANUAL: "manual",
@@ -30,6 +42,10 @@ class MaxDevice(object):
         self.room_id = None
         self.name = None
         self.serial = None
+        self.panel_locked = None
+        self.link_status = None
+        self.status_inited = None
+        self.error = None
         self.battery = None
         self.programme = None
 
@@ -49,6 +65,14 @@ class MaxDevice(object):
         state = "".join("," + s for s in args if s)
         if self.battery == MAX_DEVICE_BATTERY_LOW:
             state = ",LOW_BATT" + state
+        if self.error == MAX_DEVICE_ERROR_YES:
+            state = ",ERROR" + state
+        if self.link_status == MAX_DEVICE_LINK_STATUS_ERROR:
+            state = ",LINK_ERROR" + state
+        if self.panel_locked == MAX_DEVICE_PANEL_LOCKED:
+            state = ",LOCKED" + state
+        if self.status_inited == MAX_DEVICE_STATUS_NOT_INITIALIZED:
+            state = ",NOT_INITIALIZED" + state
         return f"{kind} sn={self.serial},rf={self.rf_address},name={self.name}" + state
 
     def __str__(self):


### PR DESCRIPTION
Recently one of my thermostats stopped responding, even button presses didn't do anything. Had to remove batteries. I noticed not working thermostat only because the room temperature was too low.

To avoid this situation in the future, I plan to monitor `error` and `link_error` attributes with HomeAssistant.

Also exposed `initialized`, not sure what is it.

And exposed `panel lock` - seems nice to have it. In the future would like to have the ability to set it with API.

---

Based on [L message](https://github.com/Bouni/max-cube-protocol/blob/master/L-Message.md) documentation, extracted additional properties for devices:
- error - not sure what that means, some of my devices have this flag set, but they seem to be functioning
- link error - some of my devices sometimes get this error
- panel lock - tested, works. Setting this flag via API would be nice, have to investigate how to do that
- initialized - not sure what is it

---

L-message contains also `valid` flag. Not sure what is it, maybe should expose that also? Does anybody know what is it?