### PR TITLE
Fix programme wall thermostat

### DIFF
--- a/maxcube/cube.py
+++ b/maxcube/cube.py
@@ -148,7 +148,8 @@ class MaxCube(MaxDevice):
             device.eco_temperature = data[19] / 2.0
             device.max_temperature = data[20] / 2.0
             device.min_temperature = data[21] / 2.0
-
+            device.programme = get_programme(data[22:204])
+            
         if device and device.is_windowshutter():
             # Pure Speculation based on this:
             # Before: [17][12][162][178][4][0][20][15]KEQ0839778

--- a/maxcube/wallthermostat.py
+++ b/maxcube/wallthermostat.py
@@ -1,5 +1,17 @@
+from datetime import datetime
+from typing import Dict, List
+
 from maxcube.device import MODE_NAMES, MaxDevice
 
+PROG_DAYS = [
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
+    "sunday",
+]
 
 class MaxWallThermostat(MaxDevice):
     def __init__(self):
@@ -11,7 +23,8 @@ class MaxWallThermostat(MaxDevice):
         self.actual_temperature = None
         self.target_temperature = None
         self.mode = None
-
+        self.programme: Dict[str, List[Dict[str, int]]] = {}
+        
     def __str__(self):
         return self.describe(
             "WALLTHERMO",
@@ -22,3 +35,16 @@ class MaxWallThermostat(MaxDevice):
             f"comfort={self.comfort_temperature}",
             f"range=[{self.min_temperature},{self.max_temperature}]",
         )
+
+    def get_programmed_temp_at(self, dt: datetime):
+        """Retrieve the programmed temperature at the given instant."""
+        weekday = PROG_DAYS[dt.weekday()]
+        time = f"{dt.hour:02}:{dt.minute:02}"
+        for point in self.programme.get(weekday, []):
+            if time < point["until"]:
+                return point["temp"]
+        return None
+
+    def get_current_temp_in_auto_mode(self):
+        """DEPRECATED: use get_programmed_temp_at instead."""
+        return self.get_programmed_temp_at(datetime.now())


### PR DESCRIPTION
The original API gets the weekly program only from the radiator thermostat.
This creates problem with the HOME ASSISTANT integration since it's not possible to set automatic mode on wall thermostats.
The fix gets the weekly program also from wall thermostat.